### PR TITLE
Remove forcing toolchain version

### DIFF
--- a/src/main/kotlin/dev/deftu/gradle/tools/java.gradle.kts
+++ b/src/main/kotlin/dev/deftu/gradle/tools/java.gradle.kts
@@ -1,7 +1,6 @@
 package dev.deftu.gradle.tools
 
 import org.gradle.api.tasks.compile.JavaCompile
-import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.java
 import org.gradle.kotlin.dsl.withType
 import dev.deftu.gradle.utils.getMajorJavaVersion
@@ -42,9 +41,5 @@ if (version != 0) {
         withType<JavaCompile> {
             applyCompilerOptions(this)
         }
-    }
-
-    extensions.configure<JavaPluginExtension> {
-        toolchain.languageVersion.set(JavaLanguageVersion.of(version))
     }
 }

--- a/src/main/kotlin/dev/deftu/gradle/tools/jvm/kotlin.gradle.kts
+++ b/src/main/kotlin/dev/deftu/gradle/tools/jvm/kotlin.gradle.kts
@@ -1,6 +1,5 @@
 package dev.deftu.gradle.tools.jvm
 
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import dev.deftu.gradle.utils.getMajorJavaVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -11,12 +10,6 @@ if (version != 0) {
     tasks.withType<KotlinCompile> {
         compilerOptions {
             jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
-        }
-    }
-
-    configure<KotlinJvmProjectExtension> {
-        jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of(version))
         }
     }
 }


### PR DESCRIPTION
As explained by https://github.com/gradle/gradle/issues/31160, using Java 8 for compiling instead of using the --release arg in Java 9+ causes error messages to not have line information.